### PR TITLE
rename pre-configured converters to `serializer`

### DIFF
--- a/django_cattrs_fields/converters/bson.py
+++ b/django_cattrs_fields/converters/bson.py
@@ -16,16 +16,16 @@ from .register_hooks import (
     register_datetime_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
+register_structure_hooks(serializer)
 
-register_unstructure_hooks(converter)
-register_datetime_unstructure_hooks(converter)
+register_unstructure_hooks(serializer)
+register_datetime_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: Binary.from_uuid(x))
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(UUIDField, lambda x: Binary.from_uuid(x))
+    serializer.register_unstructure_hook(
         Union[UUIDField, None], lambda x: Binary.from_uuid(x) if x else None
     )
 
@@ -39,16 +39,16 @@ if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
             return None
         return bson_uuid_structure(val, _)
 
-    converter.register_unstructure_hook(DateField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_structure_hook(UUIDField, bson_uuid_structure)
-    converter.register_structure_hook(Union[UUIDField, None], bson_uuid_structure_nullable)
+    serializer.register_structure_hook(UUIDField, bson_uuid_structure)
+    serializer.register_structure_hook(Union[UUIDField, None], bson_uuid_structure_nullable)
 
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/cbor2.py
+++ b/django_cattrs_fields/converters/cbor2.py
@@ -15,17 +15,17 @@ from .register_hooks import (
     register_uuid_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
-register_unstructure_hooks(converter)
-register_datetime_unstructure_hooks(converter)
-register_date_unstructure_hooks(converter)
-register_decimal_unstructure_hooks(converter)
-register_uuid_unstructure_hooks(converter)
+register_structure_hooks(serializer)
+register_unstructure_hooks(serializer)
+register_datetime_unstructure_hooks(serializer)
+register_date_unstructure_hooks(serializer)
+register_decimal_unstructure_hooks(serializer)
+register_uuid_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/json.py
+++ b/django_cattrs_fields/converters/json.py
@@ -13,27 +13,27 @@ from .register_hooks import (
     register_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
 
-register_structure_hooks(converter)
-register_unstructure_hooks(converter)
+register_structure_hooks(serializer)
+register_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: str(x))
-    converter.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
+    serializer.register_unstructure_hook(UUIDField, lambda x: str(x))
+    serializer.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
 
-    converter.register_unstructure_hook(DateField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateTimeField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/msgpack.py
+++ b/django_cattrs_fields/converters/msgpack.py
@@ -13,27 +13,27 @@ from .register_hooks import (
     register_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
-register_unstructure_hooks(converter)
+register_structure_hooks(serializer)
+register_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: str(x))
-    converter.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
+    serializer.register_unstructure_hook(UUIDField, lambda x: str(x))
+    serializer.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
 
-    converter.register_unstructure_hook(DateField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateTimeField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/msgspec.py
+++ b/django_cattrs_fields/converters/msgspec.py
@@ -5,9 +5,9 @@ from .register_hooks import (
     register_all_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
-register_all_unstructure_hooks(converter)
+register_structure_hooks(serializer)
+register_all_unstructure_hooks(serializer)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/orjson.py
+++ b/django_cattrs_fields/converters/orjson.py
@@ -15,18 +15,18 @@ from .register_hooks import (
     register_uuid_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
+register_structure_hooks(serializer)
 
-register_unstructure_hooks(converter)
-register_uuid_unstructure_hooks(converter)
-register_date_unstructure_hooks(converter)
-register_datetime_unstructure_hooks(converter)
-register_time_unstructure_hooks(converter)
+register_unstructure_hooks(serializer)
+register_uuid_unstructure_hooks(serializer)
+register_date_unstructure_hooks(serializer)
+register_datetime_unstructure_hooks(serializer)
+register_time_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/pyyaml.py
+++ b/django_cattrs_fields/converters/pyyaml.py
@@ -16,22 +16,22 @@ from .register_hooks import (
     register_time_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
+register_structure_hooks(serializer)
 
-register_unstructure_hooks(converter)
-register_date_unstructure_hooks(converter)
-register_datetime_unstructure_hooks(converter)
-register_time_unstructure_hooks(converter)
+register_unstructure_hooks(serializer)
+register_date_unstructure_hooks(serializer)
+register_datetime_unstructure_hooks(serializer)
+register_time_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: str(x))
-    converter.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(UUIDField, lambda x: str(x))
+    serializer.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/tomlkit.py
+++ b/django_cattrs_fields/converters/tomlkit.py
@@ -13,18 +13,18 @@ from .register_hooks import (
     register_time_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
-register_structure_hooks(converter)
+register_structure_hooks(serializer)
 
-register_unstructure_hooks(converter)
-register_date_unstructure_hooks(converter)
-register_datetime_unstructure_hooks(converter)
-register_time_unstructure_hooks(converter)
+register_unstructure_hooks(serializer)
+register_date_unstructure_hooks(serializer)
+register_datetime_unstructure_hooks(serializer)
+register_time_unstructure_hooks(serializer)
 
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: str(x))
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(UUIDField, lambda x: str(x))
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/django_cattrs_fields/converters/ujson.py
+++ b/django_cattrs_fields/converters/ujson.py
@@ -13,26 +13,26 @@ from .register_hooks import (
     register_unstructure_hooks,
 )
 
-converter = make_converter()
+serializer = make_converter()
 
 
-register_structure_hooks(converter)
-register_unstructure_hooks(converter)
+register_structure_hooks(serializer)
+register_unstructure_hooks(serializer)
 
 if getattr(settings, "DCF_SERIALIZER_HOOKS", True):
-    converter.register_unstructure_hook(UUIDField, lambda x: str(x))
-    converter.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
-    converter.register_unstructure_hook(DateField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(UUIDField, lambda x: str(x))
+    serializer.register_unstructure_hook(Union[UUIDField, None], lambda x: str(x) if x else None)
+    serializer.register_unstructure_hook(DateField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
-    converter.register_unstructure_hook(
+    serializer.register_unstructure_hook(DateTimeField, lambda x: x.isoformat())
+    serializer.register_unstructure_hook(
         Union[DateTimeField, None], lambda x: x.isoformat() if x else None
     )
-    converter.register_unstructure_hook(DecimalField, decimal_unstructure_str)
-    converter.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
-    converter.register_unstructure_hook(TimeField, time_unstructure_str)
-    converter.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
+    serializer.register_unstructure_hook(DecimalField, decimal_unstructure_str)
+    serializer.register_unstructure_hook(Union[DecimalField, None], decimal_unstructure_str)
+    serializer.register_unstructure_hook(TimeField, time_unstructure_str)
+    serializer.register_unstructure_hook(Union[TimeField, None], time_unstructure_str)
 
-__all__ = ("converter",)
+__all__ = ("serializer",)

--- a/tests/books/views.py
+++ b/tests/books/views.py
@@ -6,7 +6,7 @@ from django.http.response import HttpResponse
 import attrs
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.json import converter as json_converter
+from django_cattrs_fields.converters.json import serializer as json_serializer
 from django_cattrs_fields.fields.files import FileField
 
 from .models import Book
@@ -41,5 +41,5 @@ def view(request: HttpRequest) -> HttpResponseBase:
         return HttpResponse("done")
 
     b = Book.objects.last()
-    data = json_converter.dumps(converter.structure({"pdf": b.pdf}, BookData))
+    data = json_serializer.dumps(converter.structure({"pdf": b.pdf}, BookData))
     return HttpResponse(data)

--- a/tests/test_boolean_fields.py
+++ b/tests/test_boolean_fields.py
@@ -15,15 +15,15 @@ import tomlkit
 from msgspec import json as msgspec_json
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.bson import converter as bson_converter
-from django_cattrs_fields.converters.cbor2 import converter as cbor2_converter
-from django_cattrs_fields.converters.json import converter as json_converter
-from django_cattrs_fields.converters.msgpack import converter as msgpack_converter
-from django_cattrs_fields.converters.msgspec import converter as msgspec_converter
-from django_cattrs_fields.converters.orjson import converter as orjson_converter
-from django_cattrs_fields.converters.pyyaml import converter as pyyaml_converter
-from django_cattrs_fields.converters.tomlkit import converter as tomlkit_converter
-from django_cattrs_fields.converters.ujson import converter as ujson_converter
+from django_cattrs_fields.converters.bson import serializer as bson_serializer
+from django_cattrs_fields.converters.cbor2 import serializer as cbor2_serializer
+from django_cattrs_fields.converters.json import serializer as json_serializer
+from django_cattrs_fields.converters.msgpack import serializer as msgpack_serializer
+from django_cattrs_fields.converters.msgspec import serializer as msgspec_serializer
+from django_cattrs_fields.converters.orjson import serializer as orjson_serializer
+from django_cattrs_fields.converters.pyyaml import serializer as pyyaml_serializer
+from django_cattrs_fields.converters.tomlkit import serializer as tomlkit_serializer
+from django_cattrs_fields.converters.ujson import serializer as ujson_serializer
 from django_cattrs_fields.fields import BooleanField
 
 
@@ -97,15 +97,15 @@ def test_unstructure_nullable():
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps(converter, dumps):
@@ -120,14 +120,14 @@ def test_dumps(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps_null(converter, dumps):
@@ -142,15 +142,15 @@ def test_dumps_null(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads(converter, dumps):
@@ -165,14 +165,14 @@ def test_loads(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads_null(converter, dumps):
@@ -187,15 +187,15 @@ def test_loads_null(converter, dumps):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (tomlkit_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (tomlkit_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load(converter):
@@ -211,14 +211,14 @@ def test_dump_then_load(converter):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load_null(converter):

--- a/tests/test_character_fields.py
+++ b/tests/test_character_fields.py
@@ -16,15 +16,15 @@ import tomlkit
 from msgspec import json as msgspec_json
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.bson import converter as bson_converter
-from django_cattrs_fields.converters.cbor2 import converter as cbor2_converter
-from django_cattrs_fields.converters.json import converter as json_converter
-from django_cattrs_fields.converters.msgpack import converter as msgpack_converter
-from django_cattrs_fields.converters.msgspec import converter as msgspec_converter
-from django_cattrs_fields.converters.orjson import converter as orjson_converter
-from django_cattrs_fields.converters.pyyaml import converter as pyyaml_converter
-from django_cattrs_fields.converters.tomlkit import converter as tomlkit_converter
-from django_cattrs_fields.converters.ujson import converter as ujson_converter
+from django_cattrs_fields.converters.bson import serializer as bson_serializer
+from django_cattrs_fields.converters.cbor2 import serializer as cbor2_serializer
+from django_cattrs_fields.converters.json import serializer as json_serializer
+from django_cattrs_fields.converters.msgpack import serializer as msgpack_serializer
+from django_cattrs_fields.converters.msgspec import serializer as msgspec_serializer
+from django_cattrs_fields.converters.orjson import serializer as orjson_serializer
+from django_cattrs_fields.converters.pyyaml import serializer as pyyaml_serializer
+from django_cattrs_fields.converters.tomlkit import serializer as tomlkit_serializer
+from django_cattrs_fields.converters.ujson import serializer as ujson_serializer
 from django_cattrs_fields.fields import (
     CharField,
     EmailField,
@@ -233,15 +233,15 @@ def test_unstructure_nullable(name, email, slug, website, unique_id):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps(converter, dumps):
@@ -252,14 +252,14 @@ def test_dumps(converter, dumps):
         "website": "https://bob.com",
         "unique_id": str(uuid.uuid4()),
     }
-    if converter is cbor2_converter or converter is bson_converter:
+    if converter is cbor2_serializer or converter is bson_serializer:
         w["unique_id"] = uuid.uuid4()  # pyright: ignore[reportArgumentType]
 
     structure = converter.structure(w, Worker)
 
     dump = converter.dumps(structure)
 
-    if converter is bson_converter:
+    if converter is bson_serializer:
         w["unique_id"] = bson.Binary.from_uuid(w["unique_id"])
 
     assert dump == dumps(w)
@@ -268,14 +268,14 @@ def test_dumps(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads(converter, dumps):
@@ -286,9 +286,9 @@ def test_loads(converter, dumps):
         "website": "https://bob.com",
         "unique_id": str(uuid.uuid4()),
     }
-    if converter is cbor2_converter or converter is bson_converter:
+    if converter is cbor2_serializer or converter is bson_serializer:
         w["unique_id"] = uuid.uuid4()  # pyright: ignore[reportArgumentType]
-        if converter is bson_converter:
+        if converter is bson_serializer:
             w["unique_id"] = bson.Binary.from_uuid(w["unique_id"])  # pyright: ignore[reportArgumentType]
 
     dump = dumps(w)
@@ -307,14 +307,14 @@ def test_loads(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads_null(converter, dumps, name, email, slug, website, unique_id):
@@ -325,9 +325,9 @@ def test_loads_null(converter, dumps, name, email, slug, website, unique_id):
         "website": website,
         "unique_id": str(unique_id) if unique_id else None,
     }
-    if converter is cbor2_converter:
+    if converter is cbor2_serializer:
         w["unique_id"] = unique_id  # pyright: ignore[reportArgumentType]
-    if converter is bson_converter and unique_id:
+    if converter is bson_serializer and unique_id:
         w["unique_id"] = bson.Binary.from_uuid(unique_id)
 
     dump = dumps(w)
@@ -340,15 +340,15 @@ def test_loads_null(converter, dumps, name, email, slug, website, unique_id):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (tomlkit_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (tomlkit_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load(converter):
@@ -359,9 +359,9 @@ def test_dump_then_load(converter):
         "website": "https://bob.com",
         "unique_id": str(uuid.uuid4()),
     }
-    if converter is cbor2_converter or converter is bson_converter:
+    if converter is cbor2_serializer or converter is bson_serializer:
         w["unique_id"] = uuid.uuid4()  # pyright: ignore[reportArgumentType]
-        if converter is bson_converter:
+        if converter is bson_serializer:
             w["unique_id"] = bson.Binary.from_uuid(w["unique_id"])  # pyright: ignore[reportArgumentType]
 
     structure = converter.structure(w, Worker)
@@ -380,14 +380,14 @@ def test_dump_then_load(converter):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load_null(converter, name, email, slug, website, unique_id):
@@ -398,9 +398,9 @@ def test_dump_then_load_null(converter, name, email, slug, website, unique_id):
         "website": website,
         "unique_id": str(unique_id) if unique_id else None,
     }
-    if converter is cbor2_converter or converter is bson_converter:
+    if converter is cbor2_serializer or converter is bson_serializer:
         w["unique_id"] = uuid.uuid4()  # pyright: ignore[reportArgumentType]
-        if converter is bson_converter:
+        if converter is bson_serializer:
             w["unique_id"] = bson.Binary.from_uuid(w["unique_id"])  # pyright: ignore[reportArgumentType]
 
     structure = converter.structure(w, WorkerNullable)

--- a/tests/test_date_fields.py
+++ b/tests/test_date_fields.py
@@ -16,15 +16,15 @@ import tomlkit
 from msgspec import json as msgspec_json
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.bson import converter as bson_converter
-from django_cattrs_fields.converters.cbor2 import converter as cbor2_converter
-from django_cattrs_fields.converters.json import converter as json_converter
-from django_cattrs_fields.converters.msgpack import converter as msgpack_converter
-from django_cattrs_fields.converters.msgspec import converter as msgspec_converter
-from django_cattrs_fields.converters.orjson import converter as orjson_converter
-from django_cattrs_fields.converters.pyyaml import converter as pyyaml_converter
-from django_cattrs_fields.converters.tomlkit import converter as tomlkit_converter
-from django_cattrs_fields.converters.ujson import converter as ujson_converter
+from django_cattrs_fields.converters.bson import serializer as bson_serializer
+from django_cattrs_fields.converters.cbor2 import serializer as cbor2_serializer
+from django_cattrs_fields.converters.json import serializer as json_serializer
+from django_cattrs_fields.converters.msgpack import serializer as msgpack_serializer
+from django_cattrs_fields.converters.msgspec import serializer as msgspec_serializer
+from django_cattrs_fields.converters.orjson import serializer as orjson_serializer
+from django_cattrs_fields.converters.pyyaml import serializer as pyyaml_serializer
+from django_cattrs_fields.converters.tomlkit import serializer as tomlkit_serializer
+from django_cattrs_fields.converters.ujson import serializer as ujson_serializer
 from django_cattrs_fields.fields import DateField, DateTimeField, TimeField
 from django_cattrs_fields.utils.timezone import enforce_timezone
 
@@ -137,15 +137,15 @@ def test_unstructure_nullable(b, d, t):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps(converter, dumps):
@@ -159,28 +159,28 @@ def test_dumps(converter, dumps):
     dump = converter.dumps(structure)
 
     if converter in {
-        json_converter,
-        msgpack_converter,
-        ujson_converter,
-        bson_converter,
+        json_serializer,
+        msgpack_serializer,
+        ujson_serializer,
+        bson_serializer,
     }:
         h["birth"] = b.isoformat()
 
     h["death"] = enforce_timezone(d)
     if converter in {
-        json_converter,
-        msgpack_converter,
-        ujson_converter,
+        json_serializer,
+        msgpack_serializer,
+        ujson_serializer,
     }:
         h["death"] = h["death"].isoformat()
 
     if converter in {
-        cbor2_converter,
-        ujson_converter,
-        msgpack_converter,
-        bson_converter,
-        json_converter,
-        pyyaml_converter,
+        cbor2_serializer,
+        ujson_serializer,
+        msgpack_serializer,
+        bson_serializer,
+        json_serializer,
+        pyyaml_serializer,
     }:
         h["work_start"] = h["work_start"].isoformat()
 
@@ -190,14 +190,14 @@ def test_dumps(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 @pytest.mark.parametrize(
@@ -216,10 +216,10 @@ def test_dumps_nullable(converter, dumps, b, d, t):
     dump = converter.dumps(structure)
 
     if converter in {
-        json_converter,
-        msgpack_converter,
-        ujson_converter,
-        bson_converter,
+        json_serializer,
+        msgpack_serializer,
+        ujson_serializer,
+        bson_serializer,
     }:
         if b:
             h["birth"] = b.isoformat()
@@ -229,9 +229,9 @@ def test_dumps_nullable(converter, dumps, b, d, t):
     if (
         converter
         in {
-            json_converter,
-            msgpack_converter,
-            ujson_converter,
+            json_serializer,
+            msgpack_serializer,
+            ujson_serializer,
         }
         and d
     ):
@@ -240,12 +240,12 @@ def test_dumps_nullable(converter, dumps, b, d, t):
     if (
         converter
         in {
-            msgpack_converter,
-            ujson_converter,
-            bson_converter,
-            json_converter,
-            pyyaml_converter,
-            cbor2_converter,
+            msgpack_serializer,
+            ujson_serializer,
+            bson_serializer,
+            json_serializer,
+            pyyaml_serializer,
+            cbor2_serializer,
         }
         and t
     ):
@@ -257,15 +257,15 @@ def test_dumps_nullable(converter, dumps, b, d, t):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads(converter, dumps):
@@ -283,14 +283,14 @@ def test_loads(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 @pytest.mark.parametrize(
@@ -320,16 +320,16 @@ def test_loads_nullable(converter, dumps, b, d, t):
     "converter",
     [
         pytest.param(
-            bson_converter, marks=pytest.mark.xfail
+            bson_serializer, marks=pytest.mark.xfail
         ),  # it seems bson fails to serializer datetime safely
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (tomlkit_converter),
-        (ujson_converter),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (tomlkit_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load(converter):
@@ -354,15 +354,15 @@ def test_dump_then_load(converter):
     "converter",
     [
         pytest.param(
-            bson_converter, marks=pytest.mark.xfail
+            bson_serializer, marks=pytest.mark.xfail
         ),  # it seems bson fails to work datetime safely
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (ujson_converter),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (ujson_serializer),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_file_fields.py
+++ b/tests/test_file_fields.py
@@ -23,15 +23,15 @@ import tomlkit
 from msgspec import json as msgspec_json
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.bson import converter as bson_converter
-from django_cattrs_fields.converters.cbor2 import converter as cbor2_converter
-from django_cattrs_fields.converters.json import converter as json_converter
-from django_cattrs_fields.converters.msgpack import converter as msgpack_converter
-from django_cattrs_fields.converters.msgspec import converter as msgspec_converter
-from django_cattrs_fields.converters.orjson import converter as orjson_converter
-from django_cattrs_fields.converters.pyyaml import converter as pyyaml_converter
-from django_cattrs_fields.converters.tomlkit import converter as tomlkit_converter
-from django_cattrs_fields.converters.ujson import converter as ujson_converter
+from django_cattrs_fields.converters.bson import serializer as bson_serializer
+from django_cattrs_fields.converters.cbor2 import serializer as cbor2_serializer
+from django_cattrs_fields.converters.json import serializer as json_serializer
+from django_cattrs_fields.converters.msgpack import serializer as msgpack_serializer
+from django_cattrs_fields.converters.msgspec import serializer as msgspec_serializer
+from django_cattrs_fields.converters.orjson import serializer as orjson_serializer
+from django_cattrs_fields.converters.pyyaml import serializer as pyyaml_serializer
+from django_cattrs_fields.converters.tomlkit import serializer as tomlkit_serializer
+from django_cattrs_fields.converters.ujson import serializer as ujson_serializer
 from django_cattrs_fields.fields.files import FileField
 
 from tests.books.models import Book
@@ -263,15 +263,15 @@ def test_unstructure_field_file_nullable(simple_file, db, simple):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps(db, converter, dumps, simple_file, memory_file, temp_file):
@@ -304,14 +304,14 @@ def test_dumps(db, converter, dumps, simple_file, memory_file, temp_file):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 @pytest.mark.parametrize(
@@ -352,15 +352,15 @@ def test_dumps_nullable(
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads(db, converter, dumps, simple_file, memory_file, temp_file):
@@ -388,14 +388,14 @@ def test_loads(db, converter, dumps, simple_file, memory_file, temp_file):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 @pytest.mark.parametrize(
@@ -428,15 +428,15 @@ def test_loads_nullable(
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (tomlkit_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (tomlkit_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dumps_then_loads(db, converter, simple_file, memory_file, temp_file):
@@ -474,14 +474,14 @@ def test_dumps_then_loads(db, converter, simple_file, memory_file, temp_file):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (ujson_serializer),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-from django_cattrs_fields.converters.json import converter as json_converter
+from django_cattrs_fields.converters.json import serializer as json_serializer
 
 from tests.books.models import Book
 
@@ -32,6 +32,6 @@ def test_post_empty(client):
 
 def test_get_file(client, create_book):
     result = client.get("")
-    data = json_converter.loads(result.text, dict)
+    data = json_serializer.loads(result.text, dict)
     assert "pdf" in data
     assert isinstance(data["pdf"], str)

--- a/tests/test_numeric_fields.py
+++ b/tests/test_numeric_fields.py
@@ -17,15 +17,15 @@ import tomlkit
 from msgspec import json as msgspec_json
 
 from django_cattrs_fields.converters import converter
-from django_cattrs_fields.converters.bson import converter as bson_converter
-from django_cattrs_fields.converters.cbor2 import converter as cbor2_converter
-from django_cattrs_fields.converters.json import converter as json_converter
-from django_cattrs_fields.converters.msgpack import converter as msgpack_converter
-from django_cattrs_fields.converters.msgspec import converter as msgspec_converter
-from django_cattrs_fields.converters.orjson import converter as orjson_converter
-from django_cattrs_fields.converters.pyyaml import converter as pyyaml_converter
-from django_cattrs_fields.converters.tomlkit import converter as tomlkit_converter
-from django_cattrs_fields.converters.ujson import converter as ujson_converter
+from django_cattrs_fields.converters.bson import serializer as bson_serializer
+from django_cattrs_fields.converters.cbor2 import serializer as cbor2_serializer
+from django_cattrs_fields.converters.json import serializer as json_serializer
+from django_cattrs_fields.converters.msgpack import serializer as msgpack_serializer
+from django_cattrs_fields.converters.msgspec import serializer as msgspec_serializer
+from django_cattrs_fields.converters.orjson import serializer as orjson_serializer
+from django_cattrs_fields.converters.pyyaml import serializer as pyyaml_serializer
+from django_cattrs_fields.converters.tomlkit import serializer as tomlkit_serializer
+from django_cattrs_fields.converters.ujson import serializer as ujson_serializer
 from django_cattrs_fields.fields import DecimalField, IntegerField, FloatField, Params
 
 
@@ -196,21 +196,21 @@ def test_unstructure_nullable(age, salary, accurate_salary):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps(converter, dumps):
     pn = {"age": 25, "salary": 100.5, "accurate_salary": "11.1"}
     structure = converter.structure(pn, PeopleNumbers)
-    if converter in {cbor2_converter}:
+    if converter in {cbor2_serializer}:
         pn["accurate_salary"] = Decimal(pn["accurate_salary"])
 
     dump = converter.dumps(structure)
@@ -224,14 +224,14 @@ def test_dumps(converter, dumps):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_dumps_nullable(converter, dumps, age, salary, accurate_salary):
@@ -241,7 +241,7 @@ def test_dumps_nullable(converter, dumps, age, salary, accurate_salary):
     dump = converter.dumps(structure)
 
     if accurate_salary:
-        if converter in {cbor2_converter}:
+        if converter in {cbor2_serializer}:
             pn["accurate_salary"] = Decimal(accurate_salary)
     assert dump == dumps(pn)
 
@@ -250,15 +250,15 @@ def test_dumps_nullable(converter, dumps, age, salary, accurate_salary):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (tomlkit_converter, tomlkit.dumps),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (tomlkit_serializer, tomlkit.dumps),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads(converter, dumps, age, salary, accurate_salary):
@@ -278,14 +278,14 @@ def test_loads(converter, dumps, age, salary, accurate_salary):
 @pytest.mark.parametrize(
     "converter, dumps",
     [
-        (bson_converter, bson.encode),
-        (cbor2_converter, cbor2.dumps),
-        (json_converter, json.dumps),
-        (msgpack_converter, msgpack.dumps),
-        (msgspec_converter, msgspec_json.encode),
-        (orjson_converter, orjson.dumps),
-        (pyyaml_converter, yaml.safe_dump),
-        (ujson_converter, ujson.dumps),
+        (bson_serializer, bson.encode),
+        (cbor2_serializer, cbor2.dumps),
+        (json_serializer, json.dumps),
+        (msgpack_serializer, msgpack.dumps),
+        (msgspec_serializer, msgspec_json.encode),
+        (orjson_serializer, orjson.dumps),
+        (pyyaml_serializer, yaml.safe_dump),
+        (ujson_serializer, ujson.dumps),
     ],
 )
 def test_loads_nullable(converter, dumps, age, salary, accurate_salary):
@@ -303,15 +303,15 @@ def test_loads_nullable(converter, dumps, age, salary, accurate_salary):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (tomlkit_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (tomlkit_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load(converter):
@@ -321,7 +321,7 @@ def test_dump_then_load(converter):
     dump = converter.dumps(structure)
     load = converter.loads(dump, PeopleNumbers)
 
-    if converter in {msgspec_converter, cbor2_converter}:
+    if converter in {msgspec_serializer, cbor2_serializer}:
         pn["accurate_salary"] = Decimal(pn["accurate_salary"])
     assert converter.unstructure(load) == pn
 
@@ -332,14 +332,14 @@ def test_dump_then_load(converter):
 @pytest.mark.parametrize(
     "converter",
     [
-        (bson_converter),
-        (cbor2_converter),
-        (json_converter),
-        (msgpack_converter),
-        (msgspec_converter),
-        (orjson_converter),
-        (pyyaml_converter),
-        (ujson_converter),
+        (bson_serializer),
+        (cbor2_serializer),
+        (json_serializer),
+        (msgpack_serializer),
+        (msgspec_serializer),
+        (orjson_serializer),
+        (pyyaml_serializer),
+        (ujson_serializer),
     ],
 )
 def test_dump_then_load_nullable(converter, age, salary, accurate_salary):
@@ -349,7 +349,7 @@ def test_dump_then_load_nullable(converter, age, salary, accurate_salary):
     dump = converter.dumps(structure)
     load = converter.loads(dump, PeopleNumbersNullable)
 
-    if converter in {msgspec_converter, cbor2_converter}:
+    if converter in {msgspec_serializer, cbor2_serializer}:
         if accurate_salary:
             pn["accurate_salary"] = Decimal(accurate_salary)
     assert converter.unstructure(load) == pn


### PR DESCRIPTION
this was done to avoid confusion when working with a normal converter and a serializer
also to emphasize that serializers shouldn't be uesd to un/structuring